### PR TITLE
feat: make rules more consistent with react and ramda

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -41,10 +41,17 @@ const configs = {
             '@typescript-eslint/prefer-readonly': 'off',
             '@typescript-eslint/prefer-readonly-parameter-types': 'off',
 
+            // Often our projects, especially in React, have interfaces that are a mix of data and methods
+            'functional/no-mixed-type': 'off',
+
             // https://github.com/sindresorhus/eslint-plugin-unicorn/issues/896
 
             'unicorn/filename-case': 'off',
             'unicorn/prefer-query-selector': 'off',
+
+            // These rules conflict with @typescript/eslint
+            'unicorn/no-useless-undefined': 'off',
+            'unicorn/prefer-spread': 'off',
         },
     },
 }

--- a/package.json
+++ b/package.json
@@ -71,5 +71,5 @@
         "jest": "~28",
         "jest:comment": "29 seems to not be compatible with yarn berry and pnp"
     },
-    "version": "1.2.2"
+    "version": "2.2.2"
 }


### PR DESCRIPTION
Disable the following rules:

functional/no-mixed-type
unicorn/no-useless-undefined
unicorn/prefer-spread

BREAKING CHANGE: will affect linting of downstream projects